### PR TITLE
Realigned the top banner

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -41,7 +41,7 @@
 **************************/
 
 /* HEADER BACKGROUND */
-#header, body.res-nightmode #header {background: #0e1a1e url(%%banner-sum17%%) left no-repeat; background-position: 0px 5px;}
+#header, body.res-nightmode #header {background: #0e1a1e url(%%banner-sum17%%) left no-repeat; background-position: 0px 0px;}
 #header-bottom-left{height: 154px;}
 
 /* HEADER SUBREDDITS */


### PR DESCRIPTION
During the IO Arcana vote, a little 'giff-IO' was added inside the 'O' in the 'DOTA 2' header text. The IO was however slightly off, and the fix for this became to simply move the background-position for the entire header-image 5 pixel down. This change has stuck around since and causes there to be a 5px black border on the top of the page instead of just having the header image take up that space.